### PR TITLE
change log.Error() to log.Errorf() and remove CollectFromFile()

### DIFF
--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -456,7 +456,7 @@ func (e *UnboundExporter) Collect(ch chan<- prometheus.Metric) {
 			prometheus.GaugeValue,
 			1.0)
 	} else {
-		log.Error("Failed to scrape socket: %s", err)
+		log.Errorf("Failed to scrape socket: %s", err)
 		ch <- prometheus.MustNewConstMetric(
 			unboundUpDesc,
 			prometheus.GaugeValue,

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -349,14 +348,6 @@ func CollectFromReader(file io.Reader, ch chan<- prometheus.Metric) error {
 		histogramBuckets)
 
 	return scanner.Err()
-}
-
-func CollectFromFile(path string, ch chan<- prometheus.Metric) error {
-	conn, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	return CollectFromReader(conn, ch)
 }
 
 func CollectFromSocket(socketFamily string, host string, tlsConfig *tls.Config, ch chan<- prometheus.Metric) error {


### PR DESCRIPTION
- `log.Error("Failed to scrape socket: %s", err)` call has formatting directive %s. Therefore, we should use `log.Errorf(...)`.
- remove unused `CollectFromFile()` function