### PR TITLE
Close Unbound stats socket after each scrape

### DIFF
--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -373,6 +373,7 @@ func CollectFromSocket(socketFamily string, host string, tlsConfig *tls.Config, 
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 	_, err = conn.Write([]byte("UBCT1 stats_noreset\n"))
 	if err != nil {
 		return err

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -356,6 +356,7 @@ func CollectFromFile(path string, ch chan<- prometheus.Metric) error {
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 	return CollectFromReader(conn, ch)
 }
 


### PR DESCRIPTION
Close the the unbound socket explicitly, at the end of CollectFromSocket, rather than relying on GC to close it for us.

I also made the same change to the unused (presumably left for debugging) `CollectFromFile` function, for consistency