### PR TITLE
Multi arch built by github actions

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -1,0 +1,43 @@
+name: build-unbound_explorer
+on:
+  create:
+    tags:
+      - ^v\d{1,}\.\d{1,}\.\d{1,}$
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    env:
+      CONTAINER_IMAGE: ghcr.io/${{github.repository}}
+      DOCKER_VERSION: ${{github.ref_name}}
+      DOCKER_TARGET_PLATFORM: linux/arm64,linux/amd64
+    steps:
+      -
+        id: checkout
+        name: Checkout the code
+        uses: actions/checkout@v2
+      -
+        id: install-qemu
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        id: install-buildx
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      -
+        id: login-registry
+        name: Log into registry
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} \
+            --password-stdin
+      -
+        id: build
+        name: Build
+        run: |
+          docker build \
+          --platform ${DOCKER_TARGET_PLATFORM} \
+          --tag ${CONTAINER_IMAGE}:${DOCKER_VERSION} \
+          --push \
+          .

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-unbound_exporter
 .idea/
+_out/*
+!_out/.keep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.17-alpine3.14 AS builder
+
+RUN apk add --no-cache \
+  build-base \
+  make \
+  curl
+
+WORKDIR /workspace
+RUN mkdir _out
+
+COPY go.mod go.sum Makefile unbound_exporter.go ./
+RUN make clean-compile
+
+FROM scratch
+COPY --from=builder /workspace/_out/unbound_explorer /usr/local/bin/unbound_exporter
+
+ENTRYPOINT ["unbound_exporter"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+SHELL := /bin/sh
+OUT := $(shell pwd)/_out
+BUILDARCH := $(shell uname -m)
+GCC := $(OUT)/$(BUILDARCH)-linux-musl-cross/bin/$(BUILDARCH)-linux-musl-gcc
+LD := $(OUT)/$(BUILDARCH)-linux-musl-cross/bin/$(BUILDARCH)-linux-musl-ld
+
+clean-compile: musl deps compile
+
+compile:
+	CGO_ENABLED=1 \
+	CC_FOR_TARGET=$(GCC) \
+	CC=$(GCC) \
+	go build \
+		-ldflags '-linkmode external -extldflags -static' \
+		-a -o _out/unbound_explorer .
+
+deps:
+	go mod tidy -v
+	go mod download
+
+musl: clean
+	(cd $(OUT); curl -LOk https://musl.cc/$(BUILDARCH)-linux-musl-cross.tgz)
+	tar zxf $(OUT)/$(BUILDARCH)-linux-musl-cross.tgz -C $(OUT)
+
+clean:
+	rm -Rf $(OUT) $(BINARY_NAME)
+	mkdir -p $(OUT)
+	touch $(OUT)/.keep

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,22 @@
 module github.com/letsencrypt/unbound_exporter
 
-go 1.16
+go 1.17
 
 require (
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/go-kit/log v0.2.0
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.32.1
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	golang.org/x/sys v0.0.0-20211112193437-faf0a1b62c6b // indirect
 	google.golang.org/protobuf v1.27.1 // indirect


### PR DESCRIPTION
Hi,

for my personal needs I adapted the repo to be built for amd64 and arch64 architectures by the action `tags.yaml`. The only contraint is on tag name to be on the form of `^v\d{1,}\.\d{1,}\.\d{1,}$` as stated in the action file.

Hope this can be helpful even for others.

Open to dicuss improvements or changes.
Dario.


PS I did a mistake on adding the whole `musl` source into `_out` folder and removing this from history git rewrote the whole history. Nothing from the past changed but I hope this is fine...
