### PR TITLE
Add new metrics for num.query.tcpout and num.query.udpout

### DIFF
--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -160,6 +160,12 @@ var (
 			nil,
 			"^num\\.query\\.tcp$"),
 		newUnboundMetric(
+			"query_tcpout_total",
+			"Total number of queries that the Unbound server made using TCP outgoing towards other servers.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.query\\.tcpout$"),
+		newUnboundMetric(
 			"query_tls_total",
 			"Total number of queries that were made using TCP TLS towards the Unbound server.",
 			prometheus.CounterValue,
@@ -171,6 +177,12 @@ var (
 			prometheus.CounterValue,
 			[]string{"type"},
 			"^num\\.query\\.type\\.([\\w]+)$"),
+		newUnboundMetric(
+			"query_udpout_total",
+			"Total number of queries that the Unbound server made using UDP outgoing towards￼other servers.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.query\\.udpout$"),
 		newUnboundMetric(
 			"request_list_current_all",
 			"Current size of the request list, including internally generated queries.",


### PR DESCRIPTION
Unbound has a statistics counter `num.query.tcpout` which measures the number of outgoing queries that Unbound has made via TCP, which was added in 1.5.0 in 2014:

https://github.com/NLnetLabs/unbound/commit/330b3219a057e0cec1045ef40aa15074e0795d65

The upcoming release of Unbound (1.16.1) should have support for a new statistics counter `num.query.udpout` which measures the number of outgoing queries that Unbound has made via UDP:

https://github.com/NLnetLabs/unbound/commit/b8163181065ccbf298411ccf2fcd2e1d05284efb

There are several configuration options that can affect the number of outgoing queries made by the server (`qname-minimisation`, `serve-expired`, `prefetch`, `target-fetch-policy`, `harden-referral-path`, etc.) and recursion itself may require making more than one outgoing query per cache miss, all of which make it useful to monitor the number of outgoing queries from the server separately from the number of incoming queries to the server, or the number of incoming queries that caused cache misses. Timeouts/retries during recursion can also affect the number of outgoing queries made.