### PR TITLE
Metrics for TLS resumes, DoH, and aggressive NSEC

### DIFF
--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -166,7 +166,7 @@ var (
 			"^num\\.query\\.tcpout$"),
 		newUnboundMetric(
 			"query_tls_total",
-			"Total number of queries that were made using TCP TLS towards the Unbound server, including DoH queries.",
+			"Total number of queries that were made using TCP TLS towards the Unbound server, including DoT and DoH queries.",
 			prometheus.CounterValue,
 			nil,
 			"^num\\.query\\.tls$"),

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -154,7 +154,7 @@ var (
 			"^num\\.query\\.edns\\.present$"),
 		newUnboundMetric(
 			"query_tcp_total",
-			"Total number of queries that were made using TCP towards the Unbound server.",
+			"Total number of queries that were made using TCP towards the Unbound server, including DoT and DoH queries.",
 			prometheus.CounterValue,
 			nil,
 			"^num\\.query\\.tcp$"),
@@ -166,10 +166,22 @@ var (
 			"^num\\.query\\.tcpout$"),
 		newUnboundMetric(
 			"query_tls_total",
-			"Total number of queries that were made using TCP TLS towards the Unbound server.",
+			"Total number of queries that were made using TCP TLS towards the Unbound server, including DoH queries.",
 			prometheus.CounterValue,
 			nil,
 			"^num\\.query\\.tls$"),
+		newUnboundMetric(
+			"query_tls_resume_total",
+			"Total number of queries that were made using TCP TLS Resume towards the Unbound server.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.query\\.tls\\.resume$"),
+		newUnboundMetric(
+			"query_https_total",
+			"Total number of queries that were made using HTTPS towards the Unbound server.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.query\\.https$"),
 		newUnboundMetric(
 			"query_types_total",
 			"Total number of queries with a given query type.",

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -183,6 +183,12 @@ var (
 			nil,
 			"^num\\.query\\.udpout$"),
 		newUnboundMetric(
+			"query_aggressive_nsec",
+			"Total number of queries that the Unbound server generated response using Aggressive NSEC.",
+			prometheus.CounterValue,
+			[]string{"rcode"},
+			"^num\\.query\\.aggressive\\.(\\w+)$"),
+		newUnboundMetric(
 			"request_list_current_all",
 			"Current size of the request list, including internally generated queries.",
 			prometheus.GaugeValue,


### PR DESCRIPTION
## Aggressive NSEC stats

This patch maps unbound's `num.query.agressive.*` stats to `query_aggressive_nsec` metrics.
This counter tracks the number of queries that unbound synthesised answers based on the cached NSEC records.

See <https://unbound.docs.nlnetlabs.nl/en/latest/topics/privacy/aggressive-nsec.html>

Closes: https://github.com/letsencrypt/unbound_exporter/issues/48

## More transport stats: TLS resumes and DoH queries

This patch adds `query_tls_resume_total` and `query_https_total` metrics, which track the number of queries received using TLS resume and DNS-over-HTTPS transport, resp.

Also the descriptions for `query_tcp_total` and `query_tls_total` are clarified that these numbers include DoT and DoH queries.