### PR TITLE
Update github actions, test on two latest go releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.1'
+          go-version: '1.21.4'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,16 +15,18 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: 
+          - 1.20.x
+          - 1.21.x
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -32,7 +34,7 @@ jobs:
       - name: go coverage
         run: |
           go test -mod=readonly -v -race -covermode=atomic -coverprofile=coverage.out ./...
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         if: success()
         with:
           file: ./coverage.out


### PR DESCRIPTION
Update actions/setup-go, actions/checkout, and codecov/codecov-action to their latest versions

Run tests against both Go 1.20 and 1.21, and release with 1.21.