### PR TITLE
Add metric for num.rpz.action

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - socket:/var/run/socket:rw
       - ./unbound-example.conf:/opt/unbound/etc/unbound/unbound.conf
+      - ./droplist.zone:/opt/unbound/etc/unbound/droplist.zone
     ports:
       - "1053:1053/udp"
       - "1053:1053/tcp"

--- a/droplist.zone
+++ b/droplist.zone
@@ -1,2 +1,2 @@
-*.google.com IN A 127.0.0.1
-*.yahoo.com IN A 127.0.0.1
+*.example.com IN A 127.0.0.1
+*.example.net IN A 127.0.0.1

--- a/droplist.zone
+++ b/droplist.zone
@@ -1,0 +1,2 @@
+*.google.com IN A 127.0.0.1
+*.yahoo.com IN A 127.0.0.1

--- a/unbound-example.conf
+++ b/unbound-example.conf
@@ -7,11 +7,13 @@ remote-control:
 # The rest of this file is standard Unbound configuration
 # There's nothing special here.
 server:
+    module-config: "respip validator iterator"
+    extended-statistics: yes
     cache-max-ttl: 86400
     cache-min-ttl: 300
     directory: "/opt/unbound/etc/unbound"
     do-ip4: yes
-    do-ip6: no 
+    do-ip6: no
     do-tcp: yes
     do-udp: yes
     edns-buffer-size: 1232
@@ -53,7 +55,7 @@ server:
     access-control: 10.0.0.0/8 allow
     access-control: fc00::/7 allow
     access-control: ::1/128 allow
-    auto-trust-anchor-file: "var/root.key"
+    auto-trust-anchor-file: "/opt/unbound/etc/unbound/var/root.key"
     chroot: ""
     deny-any: yes
     harden-algo-downgrade: yes
@@ -65,7 +67,7 @@ server:
     harden-short-bufsize: yes
     hide-http-user-agent: no
     hide-identity: yes
-    hide-version: yes
+    hide-version: no
     http-user-agent: "DNS"
     identity: "DNS"
     private-address: 10.0.0.0/8
@@ -82,3 +84,10 @@ server:
     val-clean-additional: yes
     include: /opt/unbound/etc/unbound/a-records.conf
     include: /opt/unbound/etc/unbound/srv-records.conf
+
+rpz:
+    name: unbound_exporter_cloak
+    zonefile: /opt/unbound/etc/unbound/droplist.zone
+    rpz-log: yes
+    rpz-log-name: unbound_exporter_cloak
+    rpz-action-override: nxdomain

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -320,6 +320,13 @@ var (
 			prometheus.GaugeValue,
 			nil,
 			"^rrset\\.cache\\.count$"),
+		newUnboundMetric(
+			"rpz_action_count",
+			"Total number of triggered Response Policy Zone actions, by action.",
+			prometheus.CounterValue,
+			[]string{"type"},
+			"^num\\.rpz\\.action\\.rpz-([\\w-]+)$",
+		),
 	}
 )
 

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -322,7 +322,7 @@ var (
 			"^rrset\\.cache\\.count$"),
 		newUnboundMetric(
 			"rpz_action_count",
-			"Total number of triggered Response Policy Zone actions, by action.",
+			"Total number of triggered Response Policy Zone actions, by type.",
 			prometheus.CounterValue,
 			[]string{"type"},
 			"^num\\.rpz\\.action\\.rpz-([\\w-]+)$",


### PR DESCRIPTION
Enables rpz support in the example unbound config and gathering a metric for each triggered rpz action.
```
$ curl -s localhost:9167/metrics | grep rpz
# HELP unbound_rpz_action_count Total number of triggered Response Policy Zone actions, by action.
# TYPE unbound_rpz_action_count counter
unbound_rpz_action_count{type="nxdomain"} 1
```

Fixes https://github.com/letsencrypt/unbound_exporter/issues/69