### PR TITLE
Add subnet cache metrics.

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -51,6 +51,8 @@ func TestIntegration(t *testing.T) {
 		"unbound_cache_hits_total",
 		"unbound_query_https_total",
 		"unbound_memory_doh_bytes",
+		"unbound_query_subnet_total",
+		"unbound_query_subnet_cache_total",
 	} {
 		if _, ok := metrics[metric]; !ok {
 			t.Errorf("Expected metric is missing: %s", metric)

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -81,6 +81,18 @@ var (
 			[]string{"thread"},
 			"^thread(\\d+)\\.num\\.cachemiss$"),
 		newUnboundMetric(
+			"query_subnet_total",
+			"Total number of queries that got an answer that contained EDNS client subnet data.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.query\\.subnet$"),
+		newUnboundMetric(
+			"query_subnet_cache_total",
+			"Total number of queries answered from the edns client subnet cache.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.query\\.subnet_cache$"),
+		newUnboundMetric(
 			"queries_cookie_client_total",
 			"Total number of queries with a client cookie.",
 			prometheus.CounterValue,


### PR DESCRIPTION
From [Unbound-Control Doc](https://unbound.docs.nlnetlabs.nl/en/latest/manpages/unbound-control.html#commands):
```
# Number of queries that got an answer that contained EDNS client subnet data.
num.query.subnet

# Number of queries answered from the edns client subnet cache. 
# These are counted as cachemiss by the main counters, but hit the client subnet specific cache after getting processed by the edns client subnet module.
num.query.subnet_cache
```