### PR TITLE
Add version collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY go.sum .
 
 RUN go mod download
 
-COPY *.go .
+COPY . .
 
 ENV CGO_ENABLED=0
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,11 +3,11 @@
 package main
 
 import (
-	"github.com/prometheus/common/model"
 	"net/http"
 	"testing"
 
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
 
 // TestIntegration checks that unbound_exporter is running, successfully
@@ -47,6 +47,7 @@ func TestIntegration(t *testing.T) {
 	// Check some expected metrics are present
 	for _, metric := range []string{
 		"go_info",
+		"unbound_exporter_build_info",
 		"unbound_queries_total",
 		"unbound_response_time_seconds",
 		"unbound_cache_hits_total",

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promslog"
 )
@@ -569,6 +570,7 @@ func main() {
 		panic(err)
 	}
 	prometheus.MustRegister(exporter)
+	prometheus.MustRegister(version.NewCollector("unbound_exporter"))
 
 	http.Handle(*metricsPath, promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adds a new unbound_exporter_build_info metric. Most of our other Go packages include this.

It's useful for monitoring deployed versions of code via Prometheus.

In the dockerfile, copy in all files so that the toolchain knows what git commit it is being built from (instead of just *.go)
