### PR TITLE
Add a /_healthz endpoint

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -60,4 +60,14 @@ func TestIntegration(t *testing.T) {
 			t.Errorf("Expected metric is missing: %s", metric)
 		}
 	}
+
+	resp, err = http.Get("http://localhost:9167/_healthz")
+	if err != nil {
+		t.Fatalf("Failed to fetch healthz from unbound_exporter: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unbound_exporter reported unhealhty, status code: %d", resp.StatusCode)
+	}
+
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -67,7 +67,7 @@ func TestIntegration(t *testing.T) {
 	}
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unbound_exporter reported unhealhty, status code: %d", resp.StatusCode)
+		t.Fatalf("unbound_exporter reported unhealthy, status code: %d", resp.StatusCode)
 	}
 
 }

--- a/unbound_exporter.go
+++ b/unbound_exporter.go
@@ -476,6 +476,7 @@ type UnboundExporter struct {
 	tlsConfig    *tls.Config
 
 	// unboundUp is true if the last scrape was healthy. Used for /_healthz
+	// False initially, so this will return unhealthy until the first metric scrape has succeeded.
 	unboundUp atomic.Bool
 }
 


### PR DESCRIPTION
This returns 200 ok if we've successfully scraped metrics and Unbound is up.
