### PR TITLE
Add missing metrics since unbound v1.18

### DIFF
--- a/configs/unbound-example.conf
+++ b/configs/unbound-example.conf
@@ -19,6 +19,7 @@ server:
     edns-buffer-size: 1232
     interface: 0.0.0.0
     port: 1053
+    quic-port: 2853
     prefer-ip6: no
     rrset-roundrobin: yes
     username: "unbound"
@@ -48,6 +49,7 @@ server:
     do-daemonize: no
     do-not-query-localhost: no
     neg-cache-size: 4M
+    dns-error-reporting: yes
     qname-minimisation: yes
     access-control: 127.0.0.1/32 allow
     access-control: 192.168.0.0/16 allow

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,6 @@ services:
     ports:
       - "1053:1053/udp"
       - "1053:1053/tcp"
+      - "2853:2853/tcp" # DoQ
 volumes:
   socket:

--- a/exporter/unbound_exporter.go
+++ b/exporter/unbound_exporter.go
@@ -332,6 +332,42 @@ var (
 			prometheus.CounterValue,
 			nil,
 			"^infra\\.cache\\.count$"),
+		newUnboundMetric(
+			"memory_doq_bytes",
+			"Memory used by DoQ buffers, in bytes.",
+			prometheus.GaugeValue,
+			[]string{"buffer"},
+			"^mem\\.quic$"),
+		newUnboundMetric(
+			"query_quic_total",
+			"Total number of DNS-over-QUIC (DoQ) queries performed towards the Unbound server.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.query\\.quic$"),
+		newUnboundMetric(
+			"dns_error_reports",
+			"Total number of DNS Error Reports generated",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.dns_error_reports$"),
+		newUnboundMetric(
+			"queries_discard_timeout",
+			"Total number of queries removed due to discard-timeout.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.queries_discard_timeout$"),
+		newUnboundMetric(
+			"queries_wait_limit",
+			"Total number of queries removed due to wait-limit.",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.queries_wait_limit$"),
+		newUnboundMetric(
+			"signature_validations",
+			"Total umber of signature validation operations performed by the validator module",
+			prometheus.CounterValue,
+			nil,
+			"^num\\.valops$"),
 	}
 )
 


### PR DESCRIPTION
In https://github.com/letsencrypt/unbound_exporter/pull/94 I upgraded unbound from 1.18 to 1.24.1. Reviewing the [changelog](https://nlnetlabs.nl/projects/unbound/download/) and searching for keywords such as "stat" and "metric" lead me to find the following missing metrics that we now have access to scrape. Note that the container doesn't compile DoQ support yet per https://github.com/klutchell/unbound-docker/issues/524.

* From unbound 1.22.0: [#871](https://github.com/NLnetLabs/unbound/pull/871)
  * `num.query.quic`
  * `mem.quic`
* From unbound 1.23.0: [#902](https://github.com/NLnetLabs/unbound/pull/902) and [#1159](https://github.com/NLnetLabs/unbound/pull/1159)
  * `num.dns_error_reports`
  * `num.queries_discard_timeout `
  * `num.queries_wait_limit`
* From unbound.1.24.0: [#1289](https://github.com/NLnetLabs/unbound/pull/1289)
  * `num.valops`
