### PR TITLE
Refactor: Move the metrics webserver into metrics/

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,8 +17,6 @@ import (
 	"flag"
 	"os"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/common/promslog"
 
 	"github.com/letsencrypt/unbound_exporter/exporter"
@@ -44,9 +42,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
-	prometheus.MustRegister(exp)
-	prometheus.MustRegister(version.NewCollector("unbound_exporter"))
 
 	log.Info("Starting server", "address", *listenAddress)
 	err = metrics.NewMetricServer(*listenAddress, *metricsPath, *healthPath, exp)

--- a/main.go
+++ b/main.go
@@ -14,71 +14,16 @@
 package main
 
 import (
-	"bytes"
 	"flag"
-	"html/template"
-	"net/http"
 	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors/version"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promslog"
 
 	"github.com/letsencrypt/unbound_exporter/exporter"
+	"github.com/letsencrypt/unbound_exporter/metrics"
 )
-
-const homePageTemplate string = `
-<!DOCTYPE html>
-<html>
-	<head><title>Unbound Exporter</title></head>
-	<body>
-		<h1>Unbound Exporter</h1>
-		<p><a href='{{ .MetricsPath }}'>Metrics</a></p>
-		<p><a href='{{ .HealthPath }}'>Health</a></p>
-	</body>
-</html>
-`
-
-// homePageText renders the html template for the homepage with the user-configured links
-func homePageText(metricsPath, healthPath string) []byte {
-	tmpl := template.Must(template.New("homePage").Parse(homePageTemplate))
-
-	var out bytes.Buffer
-	err := tmpl.Execute(&out, struct {
-		MetricsPath string
-		HealthPath  string
-	}{
-		MetricsPath: metricsPath,
-		HealthPath:  healthPath,
-	})
-	if err != nil {
-		panic(err) // Unreachable: Template is static and known to be well-formed
-	}
-	return out.Bytes()
-}
-
-// newMetricServer starts the http server on listenAddress
-func newMetricsServer(listenAddress, metricsPath, healthPath string, exp *exporter.UnboundExporter) error {
-	http.Handle(metricsPath, promhttp.Handler())
-
-	http.HandleFunc(healthPath, func(w http.ResponseWriter, req *http.Request) {
-		if exp.UnboundUp() {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
-		} else {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte("sad"))
-		}
-	})
-
-	renderedHomePage := homePageText(metricsPath, healthPath)
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(renderedHomePage)
-	})
-
-	return http.ListenAndServe(listenAddress, nil)
-}
 
 func main() {
 	log := promslog.New(&promslog.Config{})
@@ -104,7 +49,7 @@ func main() {
 	prometheus.MustRegister(version.NewCollector("unbound_exporter"))
 
 	log.Info("Starting server", "address", *listenAddress)
-	err = newMetricsServer(*listenAddress, *metricsPath, *healthPath, exp)
+	err = metrics.NewMetricServer(*listenAddress, *metricsPath, *healthPath, exp)
 	if err != nil {
 		log.Error("Listen failed", "err", err.Error())
 		os.Exit(1)

--- a/metrics/metrics_server.go
+++ b/metrics/metrics_server.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"bytes"
+	"html/template"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/letsencrypt/unbound_exporter/exporter"
+)
+
+const homePageTemplate string = `
+<!DOCTYPE html>
+<html>
+	<head><title>Unbound Exporter</title></head>
+	<body>
+		<h1>Unbound Exporter</h1>
+		<p><a href='{{ .MetricsPath }}'>Metrics</a></p>
+		<p><a href='{{ .HealthPath }}'>Health</a></p>
+	</body>
+</html>
+`
+
+// homePageText renders the html template for the homepage with the user-configured links
+func homePageText(metricsPath, healthPath string) []byte {
+	tmpl := template.Must(template.New("homePage").Parse(homePageTemplate))
+
+	var out bytes.Buffer
+	err := tmpl.Execute(&out, struct {
+		MetricsPath string
+		HealthPath  string
+	}{
+		MetricsPath: metricsPath,
+		HealthPath:  healthPath,
+	})
+	if err != nil {
+		panic(err) // Unreachable: Template is static and known to be well-formed
+	}
+	return out.Bytes()
+}
+
+// NewMetricServer starts the http server on listenAddress
+func NewMetricServer(listenAddress, metricsPath, healthPath string, exp *exporter.UnboundExporter) error {
+	http.Handle(metricsPath, promhttp.Handler())
+
+	http.HandleFunc(healthPath, func(w http.ResponseWriter, req *http.Request) {
+		if exp.UnboundUp() {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("sad"))
+		}
+	})
+
+	renderedHomePage := homePageText(metricsPath, healthPath)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(renderedHomePage)
+	})
+
+	return http.ListenAndServe(listenAddress, nil)
+}

--- a/metrics/metrics_server.go
+++ b/metrics/metrics_server.go
@@ -5,6 +5,8 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/letsencrypt/unbound_exporter/exporter"
@@ -42,6 +44,9 @@ func homePageText(metricsPath, healthPath string) []byte {
 
 // NewMetricServer starts the http server on listenAddress
 func NewMetricServer(listenAddress, metricsPath, healthPath string, exp *exporter.UnboundExporter) error {
+	prometheus.MustRegister(exp)
+	prometheus.MustRegister(version.NewCollector("unbound_exporter"))
+
 	http.Handle(metricsPath, promhttp.Handler())
 
 	http.HandleFunc(healthPath, func(w http.ResponseWriter, req *http.Request) {

--- a/metrics/metrics_server_test.go
+++ b/metrics/metrics_server_test.go
@@ -1,4 +1,4 @@
-package main
+package metrics
 
 import "testing"
 


### PR DESCRIPTION
Keeps the main package pretty small to just flag processing and setup.
