### PR TITLE
Properly check error and exit on NewUnboundExporter failure

### DIFF
--- a/exporter/unbound_exporter.go
+++ b/exporter/unbound_exporter.go
@@ -536,7 +536,7 @@ func tlsConfig(ca string, cert string, key string) (*tls.Config, error) {
 func NewUnboundExporter(host string, ca string, cert string, key string, log *slog.Logger) (*UnboundExporter, error) {
 	u, err := url.Parse(host)
 	if err != nil {
-		return &UnboundExporter{}, err
+		return nil, err
 	}
 
 	newExporter := UnboundExporter{

--- a/main.go
+++ b/main.go
@@ -40,7 +40,8 @@ func main() {
 	log.Info("Starting unbound_exporter")
 	exp, err := exporter.NewUnboundExporter(*unboundHost, *unboundCa, *unboundCert, *unboundKey, log)
 	if err != nil {
-		panic(err)
+		log.Error("Unbound Exporter setup failed", "err", err.Error())
+		os.Exit(1)
 	}
 
 	log.Info("Starting server", "address", *listenAddress)


### PR DESCRIPTION
Log and exit 1 instead of panicing.

Plus return nil, err on error in NewUnboundExporter, as there's
no good reason to return an object here.
