### PR TITLE
Fix panic on mem.quic with a refactor for testability

### DIFF
--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,7 +26,7 @@ func TestCollect(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	err = CollectFromReader(testData, ch)
+	err = collectFromReader(compileMetrics(), testData, ch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +34,16 @@ func TestCollect(t *testing.T) {
 	close(ch)
 	<-done
 
-	if len(metrics) != 108 {
-		t.Fatal("expected 108 metrics, got ", len(metrics))
+	if len(metrics) != 109 {
+		t.Fatal("expected 109 metrics, got ", len(metrics))
+	}
+}
+
+func TestLabels(t *testing.T) {
+	for _, metric := range unboundMetrics {
+		r := regexp.MustCompile(metric.pattern)
+		if r.NumSubexp() != len(metric.labels) {
+			t.Errorf("Expected %d patterns in regex, got %d on %s", len(metric.labels), r.NumSubexp(), metric.name)
+		}
 	}
 }

--- a/exporter/testdata/metrics.txt
+++ b/exporter/testdata/metrics.txt
@@ -132,6 +132,7 @@ mem.cache.dnscrypt_nonce=0
 mem.streamwait=0
 mem.http.query_buffer=0
 mem.http.response_buffer=0
+mem.quic=0
 histogram.000000.000000.to.000000.000001=0
 histogram.000000.000001.to.000000.000002=0
 histogram.000000.000002.to.000000.000004=0

--- a/exporter/unbound_exporter.go
+++ b/exporter/unbound_exporter.go
@@ -20,6 +20,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+type metricDescription struct {
+	name        string
+	description string
+	valueType   prometheus.ValueType
+	labels      []string
+	pattern     string
+}
+
 var (
 	unboundUpDesc = prometheus.NewDesc(
 		prometheus.BuildFQName("unbound", "", "up"),
@@ -31,355 +39,413 @@ var (
 		"Query response time in seconds.",
 		nil, nil)
 
-	unboundMetrics = []*unboundMetric{
-		newUnboundMetric(
+	unboundMetrics = []metricDescription{
+		{
 			"answer_rcodes_total",
 			"Total number of answers to queries, from cache or from recursion, by response code.",
 			prometheus.CounterValue,
 			[]string{"rcode"},
-			"^num\\.answer\\.rcode\\.(\\w+)$"),
-		newUnboundMetric(
+			"^num\\.answer\\.rcode\\.(\\w+)$",
+		},
+		{
 			"answers_bogus",
 			"Total number of answers that were bogus.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.answer\\.bogus$"),
-		newUnboundMetric(
+			"^num\\.answer\\.bogus$",
+		},
+		{
 			"answers_secure_total",
 			"Total number of answers that were secure.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.answer\\.secure$"),
-		newUnboundMetric(
+			"^num\\.answer\\.secure$",
+		},
+		{
 			"cache_hits_total",
 			"Total number of queries that were successfully answered using a cache lookup.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.cachehits$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.cachehits$",
+		},
+		{
 			"cache_misses_total",
 			"Total number of cache queries that needed recursive processing.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.cachemiss$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.cachemiss$",
+		},
+		{
 			"query_subnet_total",
 			"Total number of queries that got an answer that contained EDNS client subnet data.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.subnet$"),
-		newUnboundMetric(
+			"^num\\.query\\.subnet$",
+		},
+		{
 			"query_subnet_cache_total",
 			"Total number of queries answered from the edns client subnet cache.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.subnet_cache$"),
-		newUnboundMetric(
+			"^num\\.query\\.subnet_cache$",
+		},
+		{
 			"queries_cookie_client_total",
 			"Total number of queries with a client cookie.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.queries_cookie_client$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.queries_cookie_client$",
+		},
+		{
 			"queries_cookie_invalid_total",
 			"Total number of queries with a invalid cookie.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.queries_invalid_client$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.queries_invalid_client$",
+		},
+		{
 			"queries_cookie_valid_total",
 			"Total number of queries with a valid cookie.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.queries_cookie_valid$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.queries_cookie_valid$",
+		},
+		{
 			"memory_caches_bytes",
 			"Memory in bytes in use by caches.",
 			prometheus.GaugeValue,
 			[]string{"cache"},
-			"^mem\\.cache\\.(\\w+)$"),
-		newUnboundMetric(
+			"^mem\\.cache\\.(\\w+)$",
+		},
+		{
 			"memory_modules_bytes",
 			"Memory in bytes in use by modules.",
 			prometheus.GaugeValue,
 			[]string{"module"},
-			"^mem\\.mod\\.(\\w+)$"),
-		newUnboundMetric(
+			"^mem\\.mod\\.(\\w+)$",
+		},
+		{
 			"memory_sbrk_bytes",
 			"Memory in bytes allocated through sbrk.",
 			prometheus.GaugeValue,
 			nil,
-			"^mem\\.total\\.sbrk$"),
-		newUnboundMetric(
+			"^mem\\.total\\.sbrk$",
+		},
+		{
 			"prefetches_total",
 			"Total number of cache prefetches performed.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.prefetch$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.prefetch$",
+		},
+		{
 			"queries_total",
 			"Total number of queries received.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.queries$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.queries$",
+		},
+		{
 			"expired_total",
 			"Total number of expired entries served.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.expired$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.expired$",
+		},
+		{
 			"query_classes_total",
 			"Total number of queries with a given query class.",
 			prometheus.CounterValue,
 			[]string{"class"},
-			"^num\\.query\\.class\\.([\\w]+)$"),
-		newUnboundMetric(
+			"^num\\.query\\.class\\.([\\w]+)$",
+		},
+		{
 			"query_flags_total",
 			"Total number of queries that had a given flag set in the header.",
 			prometheus.CounterValue,
 			[]string{"flag"},
-			"^num\\.query\\.flags\\.([\\w]+)$"),
-		newUnboundMetric(
+			"^num\\.query\\.flags\\.([\\w]+)$",
+		},
+		{
 			"query_ipv6_total",
 			"Total number of queries that were made using IPv6 towards the Unbound server.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.ipv6$"),
-		newUnboundMetric(
+			"^num\\.query\\.ipv6$",
+		},
+		{
 			"query_opcodes_total",
 			"Total number of queries with a given query opcode.",
 			prometheus.CounterValue,
 			[]string{"opcode"},
-			"^num\\.query\\.opcode\\.([\\w]+)$"),
-		newUnboundMetric(
+			"^num\\.query\\.opcode\\.([\\w]+)$",
+		},
+		{
 			"query_edns_DO_total",
 			"Total number of queries that had an EDNS OPT record with the DO (DNSSEC OK) bit set present.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.edns\\.DO$"),
-		newUnboundMetric(
+			"^num\\.query\\.edns\\.DO$",
+		},
+		{
 			"query_edns_present_total",
 			"Total number of queries that had an EDNS OPT record present.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.edns\\.present$"),
-		newUnboundMetric(
+			"^num\\.query\\.edns\\.present$",
+		},
+		{
 			"query_tcp_total",
 			"Total number of queries that were made using TCP towards the Unbound server, including DoT and DoH queries.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.tcp$"),
-		newUnboundMetric(
+			"^num\\.query\\.tcp$",
+		},
+		{
 			"query_tcpout_total",
 			"Total number of queries that the Unbound server made using TCP outgoing towards other servers.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.tcpout$"),
-		newUnboundMetric(
+			"^num\\.query\\.tcpout$",
+		},
+		{
 			"query_tls_total",
 			"Total number of queries that were made using TCP TLS towards the Unbound server, including DoT and DoH queries.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.tls$"),
-		newUnboundMetric(
+			"^num\\.query\\.tls$",
+		},
+		{
 			"query_tls_resume_total",
 			"Total number of queries that were made using TCP TLS Resume towards the Unbound server.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.tls\\.resume$"),
-		newUnboundMetric(
+			"^num\\.query\\.tls\\.resume$",
+		},
+		{
 			"query_https_total",
 			"Total number of DoH queries that were made towards the Unbound server.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.https$"),
-		newUnboundMetric(
+			"^num\\.query\\.https$",
+		},
+		{
 			"query_types_total",
 			"Total number of queries with a given query type.",
 			prometheus.CounterValue,
 			[]string{"type"},
-			"^num\\.query\\.type\\.([\\w]+)$"),
-		newUnboundMetric(
+			"^num\\.query\\.type\\.([\\w]+)$",
+		},
+		{
 			"query_udpout_total",
 			"Total number of queries that the Unbound server made using UDP outgoing towards￼other servers.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.udpout$"),
-		newUnboundMetric(
+			"^num\\.query\\.udpout$",
+		},
+		{
 			"query_aggressive_nsec",
 			"Total number of queries that the Unbound server generated response using Aggressive NSEC.",
 			prometheus.CounterValue,
 			[]string{"rcode"},
-			"^num\\.query\\.aggressive\\.(\\w+)$"),
-		newUnboundMetric(
+			"^num\\.query\\.aggressive\\.(\\w+)$",
+		},
+		{
 			"request_list_current_all",
 			"Current size of the request list, including internally generated queries.",
 			prometheus.GaugeValue,
 			[]string{"thread"},
-			"^thread([0-9]+)\\.requestlist\\.current\\.all$"),
-		newUnboundMetric(
+			"^thread([0-9]+)\\.requestlist\\.current\\.all$",
+		},
+		{
 			"request_list_current_replies",
 			"Current count of the number of reply entries waiting on request list entries.",
 			prometheus.GaugeValue,
 			[]string{"thread"},
-			"^thread([0-9]+)\\.requestlist\\.current\\.replies$"),
-		newUnboundMetric(
+			"^thread([0-9]+)\\.requestlist\\.current\\.replies$",
+		},
+		{
 			"request_list_current_user",
 			"Current size of the request list, only counting the requests from client queries.",
 			prometheus.GaugeValue,
 			[]string{"thread"},
-			"^thread([0-9]+)\\.requestlist\\.current\\.user$"),
-		newUnboundMetric(
+			"^thread([0-9]+)\\.requestlist\\.current\\.user$",
+		},
+		{
 			"request_list_exceeded_total",
 			"Number of queries that were dropped because the request list was full.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread([0-9]+)\\.requestlist\\.exceeded$"),
-		newUnboundMetric(
+			"^thread([0-9]+)\\.requestlist\\.exceeded$",
+		},
+		{
 			"request_list_overwritten_total",
 			"Total number of requests in the request list that were overwritten by newer entries.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread([0-9]+)\\.requestlist\\.overwritten$"),
-		newUnboundMetric(
+			"^thread([0-9]+)\\.requestlist\\.overwritten$",
+		},
+		{
 			"recursive_replies_total",
 			"Total number of replies sent to queries that needed recursive processing.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.recursivereplies$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.recursivereplies$",
+		},
+		{
 			"rrset_bogus_total",
 			"Total number of rrsets marked bogus by the validator.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.rrset\\.bogus$"),
-		newUnboundMetric(
+			"^num\\.rrset\\.bogus$",
+		},
+		{
 			"rrset_cache_max_collisions_total",
 			"Total number of rrset cache hashtable collisions.",
 			prometheus.CounterValue,
 			nil,
-			"^rrset\\.cache\\.max_collisions$"),
-		newUnboundMetric(
+			"^rrset\\.cache\\.max_collisions$",
+		},
+		{
 			"time_elapsed_seconds",
 			"Time since last statistics printout in seconds.",
 			prometheus.CounterValue,
 			nil,
-			"^time\\.elapsed$"),
-		newUnboundMetric(
+			"^time\\.elapsed$",
+		},
+		{
 			"time_now_seconds",
 			"Current time in seconds since 1970.",
 			prometheus.GaugeValue,
 			nil,
-			"^time\\.now$"),
-		newUnboundMetric(
+			"^time\\.now$",
+		},
+		{
 			"time_up_seconds_total",
 			"Uptime since server boot in seconds.",
 			prometheus.CounterValue,
 			nil,
-			"^time\\.up$"),
-		newUnboundMetric(
+			"^time\\.up$",
+		},
+		{
 			"unwanted_queries_total",
 			"Total number of queries that were refused or dropped because they failed the access control settings.",
 			prometheus.CounterValue,
 			nil,
-			"^unwanted\\.queries$"),
-		newUnboundMetric(
+			"^unwanted\\.queries$",
+		},
+		{
 			"unwanted_replies_total",
 			"Total number of replies that were unwanted or unsolicited.",
 			prometheus.CounterValue,
 			nil,
-			"^unwanted\\.replies$"),
-		newUnboundMetric(
+			"^unwanted\\.replies$",
+		},
+		{
 			"recursion_time_seconds_avg",
 			"Average time it took to answer queries that needed recursive processing (does not include in-cache requests).",
 			prometheus.GaugeValue,
 			nil,
-			"^total\\.recursion\\.time\\.avg$"),
-		newUnboundMetric(
+			"^total\\.recursion\\.time\\.avg$",
+		},
+		{
 			"recursion_time_seconds_median",
 			"The median of the time it took to answer queries that needed recursive processing.",
 			prometheus.GaugeValue,
 			nil,
-			"^total\\.recursion\\.time\\.median$"),
-		newUnboundMetric(
+			"^total\\.recursion\\.time\\.median$",
+		},
+		{
 			"msg_cache_count",
 			"The Number of Messages cached",
 			prometheus.GaugeValue,
 			nil,
-			"^msg\\.cache\\.count$"),
-		newUnboundMetric(
+			"^msg\\.cache\\.count$",
+		},
+		{
 			"msg_cache_max_collisions_total",
 			"Total number of msg cache hashtable collisions.",
 			prometheus.CounterValue,
 			nil,
-			"^msg\\.cache\\.max_collisions$"),
-		newUnboundMetric(
+			"^msg\\.cache\\.max_collisions$",
+		},
+		{
 			"rrset_cache_count",
 			"The Number of rrset cached",
 			prometheus.GaugeValue,
 			nil,
-			"^rrset\\.cache\\.count$"),
-		newUnboundMetric(
+			"^rrset\\.cache\\.count$",
+		},
+		{
 			"rpz_action_count",
 			"Total number of triggered Response Policy Zone actions, by type.",
 			prometheus.CounterValue,
 			[]string{"type"},
-			"^num\\.rpz\\.action\\.rpz-([\\w-]+)$"),
-		newUnboundMetric(
+			"^num\\.rpz\\.action\\.rpz-([\\w-]+)$",
+		},
+		{
 			"memory_doh_bytes",
 			"Memory used by DoH buffers, in bytes.",
 			prometheus.GaugeValue,
 			[]string{"buffer"},
-			"^mem\\.http\\.(\\w+)$"),
-		newUnboundMetric(
+			"^mem\\.http\\.(\\w+)$",
+		},
+		{
 			"infra_cache_count",
 			"Total number of infra cache entries",
 			prometheus.CounterValue,
 			nil,
-			"^infra\\.cache\\.count$"),
-		newUnboundMetric(
+			"^infra\\.cache\\.count$",
+		},
+		{
 			"memory_doq_bytes",
 			"Memory used by DoQ buffers, in bytes.",
 			prometheus.GaugeValue,
-			[]string{"buffer"},
-			"^mem\\.quic$"),
-		newUnboundMetric(
+			nil,
+			"^mem\\.quic$",
+		},
+		{
 			"query_quic_total",
 			"Total number of DNS-over-QUIC (DoQ) queries performed towards the Unbound server.",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.query\\.quic$"),
-		newUnboundMetric(
+			"^num\\.query\\.quic$",
+		},
+		{
 			"dns_error_reports",
 			"Total number of DNS Error Reports generated",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.dns_error_reports$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.dns_error_reports$",
+		},
+		{
 			"queries_discard_timeout",
 			"Total number of queries removed due to discard-timeout.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.queries_discard_timeout$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.queries_discard_timeout$",
+		},
+		{
 			"queries_replyaddr_limit",
 			"Total number of queries removed due to replyaddr limits.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.queries_replyaddr_limit$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.queries_replyaddr_limit$",
+		},
+		{
 			"queries_wait_limit",
 			"Total number of queries removed due to wait-limit.",
 			prometheus.CounterValue,
 			[]string{"thread"},
-			"^thread(\\d+)\\.num\\.queries_wait_limit$"),
-		newUnboundMetric(
+			"^thread(\\d+)\\.num\\.queries_wait_limit$",
+		},
+		{
 			"signature_validations",
 			"Total umber of signature validation operations performed by the validator module",
 			prometheus.CounterValue,
 			nil,
-			"^num\\.valops$"),
+			"^num\\.valops$",
+		},
 	}
 )
 
@@ -389,19 +455,25 @@ type unboundMetric struct {
 	pattern   *regexp.Regexp
 }
 
-func newUnboundMetric(name string, description string, valueType prometheus.ValueType, labels []string, pattern string) *unboundMetric {
-	return &unboundMetric{
-		desc: prometheus.NewDesc(
-			prometheus.BuildFQName("unbound", "", name),
-			description,
-			labels,
-			nil),
-		valueType: valueType,
-		pattern:   regexp.MustCompile(pattern),
+func compileMetrics() []unboundMetric {
+	metrics := make([]unboundMetric, 0, len(unboundMetrics))
+
+	for _, md := range unboundMetrics {
+		metrics = append(metrics, unboundMetric{
+			desc: prometheus.NewDesc(
+				prometheus.BuildFQName("unbound", "", md.name),
+				md.description,
+				md.labels,
+				nil),
+			valueType: md.valueType,
+			pattern:   regexp.MustCompile(md.pattern),
+		})
 	}
+
+	return metrics
 }
 
-func CollectFromReader(file io.Reader, ch chan<- prometheus.Metric) error {
+func collectFromReader(metrics []unboundMetric, file io.Reader, ch chan<- prometheus.Metric) error {
 	scanner := bufio.NewScanner(file)
 	scanner.Split(bufio.ScanLines)
 	histogramPattern := regexp.MustCompile(`^histogram\.\d+\.\d+\.to\.(\d+\.\d+)$`)
@@ -418,7 +490,7 @@ func CollectFromReader(file io.Reader, ch chan<- prometheus.Metric) error {
 				scanner.Text())
 		}
 
-		for _, metric := range unboundMetrics {
+		for _, metric := range metrics {
 			if matches := metric.pattern.FindStringSubmatch(fields[0]); matches != nil {
 				value, err := strconv.ParseFloat(fields[1], 64)
 				if err != nil {
@@ -477,7 +549,7 @@ func CollectFromReader(file io.Reader, ch chan<- prometheus.Metric) error {
 	return scanner.Err()
 }
 
-func CollectFromSocket(socketFamily string, host string, tlsConfig *tls.Config, ch chan<- prometheus.Metric) error {
+func (e *UnboundExporter) collectFromSocket(socketFamily string, host string, tlsConfig *tls.Config, ch chan<- prometheus.Metric) error {
 	var (
 		conn net.Conn
 		err  error
@@ -496,7 +568,7 @@ func CollectFromSocket(socketFamily string, host string, tlsConfig *tls.Config, 
 	if err != nil {
 		return err
 	}
-	return CollectFromReader(conn, ch)
+	return collectFromReader(e.metrics, conn, ch)
 }
 
 type UnboundExporter struct {
@@ -505,6 +577,8 @@ type UnboundExporter struct {
 	socketFamily string
 	host         string
 	tlsConfig    *tls.Config
+
+	metrics []unboundMetric
 
 	// unboundUp is true if the last scrape was healthy. Used for /_healthz
 	// False initially, so this will return unhealthy until the first metric scrape has succeeded.
@@ -555,6 +629,7 @@ func NewUnboundExporter(host string, ca string, cert string, key string, log *sl
 		log:          log,
 		socketFamily: u.Scheme,
 		host:         u.Path,
+		metrics:      compileMetrics(),
 	}
 
 	if u.Scheme == "unix" || (ca == "" && cert == "" && key == "") {
@@ -572,13 +647,13 @@ func NewUnboundExporter(host string, ca string, cert string, key string, log *sl
 
 func (e *UnboundExporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- unboundUpDesc
-	for _, metric := range unboundMetrics {
+	for _, metric := range e.metrics {
 		ch <- metric.desc
 	}
 }
 
 func (e *UnboundExporter) Collect(ch chan<- prometheus.Metric) {
-	err := CollectFromSocket(e.socketFamily, e.host, e.tlsConfig, ch)
+	err := e.collectFromSocket(e.socketFamily, e.host, e.tlsConfig, ch)
 	if err == nil {
 		e.unboundUp.Store(true)
 		ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
Fix panic on mem.quic with a refactor for testability
    
This refactors the exporter to keep an internal set of compiled metrics, instead of having them in a global variable. That means I can write tests using what was the input to newUnboundMetric.
    
Since it's not a global anymore, it has to be passed into collectFromSocket and collectFromReader. These aren't a meaningful part of the API, so make them private before changing their signatures. I've made collectFromSocket a member of UnboundExporter because I think in a future change we can also hold onto the socket longer.
    
This adds a new test that motivated the change, which verifies that the number of labels in each metric description matches the number of subexpressions in the regex, and a fix to the underlying bug.
    
Fixes #104