### PR TITLE
Set host based on scheme

### DIFF
--- a/exporter/unbound_exporter.go
+++ b/exporter/unbound_exporter.go
@@ -628,11 +628,16 @@ func NewUnboundExporter(host string, ca string, cert string, key string, log *sl
 	newExporter := UnboundExporter{
 		log:          log,
 		socketFamily: u.Scheme,
-		host:         u.Path,
 		metrics:      compileMetrics(),
 	}
 
-	if u.Scheme == "unix" || (ca == "" && cert == "" && key == "") {
+	if u.Scheme == "unix" {
+		newExporter.host = u.Path
+		return &newExporter, nil
+	}
+	newExporter.host = u.Host
+
+	if ca == "" && cert == "" && key == "" {
 		return &newExporter, nil
 	}
 


### PR DESCRIPTION
In #92, I incorrectly always set newExporter.host to u.Path, but that's
only correct for Unix sockets, which is also the only case we integration test.

For TCP/TLS connections, we should dial the u.Host

Fixes #107
