### PR TITLE
Add integration tests for TCP and TLS control

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -11,6 +11,14 @@ on:
 jobs:
   integration:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        include:
+          - test_type: unix
+          - test_type: tcp
+          - test_type: tls
+    env:
+      TEST_TYPE: ${{ matrix.test_type }}
     steps:
       - name: Install Go
         uses: actions/setup-go@v6
@@ -20,11 +28,11 @@ jobs:
         uses: actions/checkout@v6
       - name: Start containers
         working-directory: integration
-        run: docker compose up --build --detach
+        run: docker compose -f docker-compose-$TEST_TYPE.yml up --build --detach
       - name: run integration test
         working-directory: integration
         run: go test -v --tags=integration
       - name: Stop containers
         if: always()
         working-directory: integration
-        run: docker compose down
+        run: docker compose -f docker-compose-$TEST_TYPE.yml down

--- a/integration/configs/remote-control-tcp.conf
+++ b/integration/configs/remote-control-tcp.conf
@@ -1,0 +1,7 @@
+remote-control:
+    control-enable: yes
+    control-use-cert: no
+    control-interface: 0.0.0.0
+    control-port: 8953
+
+include: /etc/unbound/unbound-example.conf

--- a/integration/configs/remote-control-tcp.conf
+++ b/integration/configs/remote-control-tcp.conf
@@ -1,3 +1,4 @@
+# Set up remote control using unauthenticated TCP.
 remote-control:
     control-enable: yes
     control-use-cert: no

--- a/integration/configs/remote-control-tls.conf
+++ b/integration/configs/remote-control-tls.conf
@@ -1,3 +1,5 @@
+# Set up remote control using TLS and certificates.
+# Unbound's unbound-control-setup script can generate them.
 remote-control:
     control-enable: yes
     control-use-cert: yes

--- a/integration/configs/remote-control-tls.conf
+++ b/integration/configs/remote-control-tls.conf
@@ -1,0 +1,11 @@
+remote-control:
+    control-enable: yes
+    control-use-cert: yes
+    control-interface: 0.0.0.0
+    control-port: 8954
+    server-key-file: "/certs/unbound_server.key"
+    server-cert-file: "/certs/unbound_server.pem"
+    control-key-file: "/certs/unbound_control.key"
+    control-cert-file: "/certs/unbound_control.pem"
+
+include: /etc/unbound/unbound-example.conf

--- a/integration/configs/remote-control-unix.conf
+++ b/integration/configs/remote-control-unix.conf
@@ -1,0 +1,5 @@
+remote-control:
+    control-enable: yes
+    control-interface: /var/run/socket/unbound.ctl
+
+include: /etc/unbound/unbound-example.conf

--- a/integration/configs/remote-control-unix.conf
+++ b/integration/configs/remote-control-unix.conf
@@ -1,3 +1,4 @@
+# Set up remote control using a unix socket.
 remote-control:
     control-enable: yes
     control-interface: /var/run/socket/unbound.ctl

--- a/integration/configs/unbound-example.conf
+++ b/integration/configs/unbound-example.conf
@@ -1,11 +1,6 @@
-## This is an example Unbound configuration file
-## This is needed to use unbound_exporter
-remote-control:
-    control-enable: yes
-    control-interface: /var/run/socket/unbound.ctl
-
-# The rest of this file is standard Unbound configuration
-# There's nothing special here.
+# This is an example Unbound configuration file: There's nothing special here.
+# It is included by the remote-control-*.conf files which show the three
+# supported remote-control used by unbound-exporter.
 server:
     module-config: "respip validator iterator"
     extended-statistics: yes

--- a/integration/docker-compose-tcp.yml
+++ b/integration/docker-compose-tcp.yml
@@ -1,0 +1,21 @@
+services:
+  unbound_exporter:
+    build:
+      context: ..
+    command: [ "-unbound.host=tcp://unbound:8953", "-unbound.ca=", "-unbound.cert=", "-unbound.key=" ]
+    ports:
+      - "9167:9167"
+    depends_on:
+      unbound:
+        condition: service_started
+
+  unbound:
+    build:
+      context: .
+      dockerfile: unbound.Containerfile
+    command: [ "/usr/local/sbin/unbound", "-v", "-d", "-c", "/etc/unbound/remote-control-tcp.conf" ]
+    ports:
+      - "1053:1053/udp"
+      - "1053:1053/tcp"
+      - "2853:2853/tcp" # DoQ
+      - "8953:8953"

--- a/integration/docker-compose-tls.yml
+++ b/integration/docker-compose-tls.yml
@@ -1,0 +1,43 @@
+services:
+  # Setup container that generates certificates
+  setup:
+    build:
+      context: .
+      dockerfile: unbound.Containerfile
+    command: [ "/usr/local/sbin/unbound-control-setup" ]
+    volumes:
+      - certs:/usr/local/etc/unbound
+    working_dir: /certs
+
+  unbound_exporter:
+    build:
+      context: ..
+    command: [ "-unbound.host=tcp://unbound:8954", "-unbound.ca=/certs/unbound_server.pem", "-unbound.cert=/certs/unbound_control.pem", "-unbound.key=/certs/unbound_control.key" ]
+    volumes:
+      - certs:/certs:ro
+    ports:
+      - "9167:9167"
+    depends_on:
+      setup:
+        condition: service_completed_successfully
+      unbound:
+        condition: service_started
+
+  unbound:
+    build:
+      context: .
+      dockerfile: unbound.Containerfile
+    command: [ "/usr/local/sbin/unbound", "-v", "-d", "-c", "/etc/unbound/remote-control-tls.conf" ]
+    volumes:
+      - certs:/certs:ro
+    ports:
+      - "1053:1053/udp"
+      - "1053:1053/tcp"
+      - "2853:2853/tcp" # DoQ
+      - "8954:8954"
+    depends_on:
+      setup:
+        condition: service_completed_successfully
+
+volumes:
+  certs:

--- a/integration/docker-compose-tls.yml
+++ b/integration/docker-compose-tls.yml
@@ -1,5 +1,4 @@
 services:
-  # Setup container that generates certificates
   setup:
     build:
       context: .
@@ -7,7 +6,6 @@ services:
     command: [ "/usr/local/sbin/unbound-control-setup" ]
     volumes:
       - certs:/usr/local/etc/unbound
-    working_dir: /certs
 
   unbound_exporter:
     build:

--- a/integration/docker-compose-unix.yml
+++ b/integration/docker-compose-unix.yml
@@ -10,15 +10,18 @@ services:
     depends_on:
       unbound:
         condition: service_started
+
   unbound:
     build:
       context: .
       dockerfile: unbound.Containerfile
     volumes:
       - socket:/var/run/socket:rw
+    command: [ "/usr/local/sbin/unbound", "-v", "-d", "-c", "/etc/unbound/remote-control-unix.conf" ]
     ports:
       - "1053:1053/udp"
       - "1053:1053/tcp"
       - "2853:2853/tcp" # DoQ
+
 volumes:
   socket:

--- a/integration/unbound.Containerfile
+++ b/integration/unbound.Containerfile
@@ -6,7 +6,7 @@ RUN groupadd --system unbound \
   && useradd --system --no-create-home --gid unbound --shell /usr/sbin/nologin unbound
 
 RUN apt-get -y update && apt-get install -y \
-    bison flex gcc make \
+    bison flex gcc make openssl \
     libevent-dev libexpat1-dev libnghttp2-dev libngtcp2-crypto-ossl-dev libngtcp2-dev libssl-dev
 
 ADD https://github.com/NLnetLabs/unbound.git#${UNBOUND_TAG} /src/unbound


### PR DESCRIPTION
Run integration tests with TCP, TLS, and Unix socket unbound control.

This duplicates the docker-compose file that runs unbound+unbound_exporter in integration tests so there's three versions, for the three supported methods of connecting to Unbound.

To avoid duplicating the entire unbound config, I've pulled the remote-control portion into their own files and most of the logic is in a shared included file.

I think we can probably cut down on the docker-compose-* duplication but this was clearer than trying to do anything tricky.

I had copilot experiment with a few ways to do this, but in the end I mostly wrote this myself, and there's only a few snippets written by AI.

Fixes #113 
