### PR TITLE
Explicitly set minimum TLS version to TLSv1.2

### DIFF
--- a/exporter/unbound_exporter.go
+++ b/exporter/unbound_exporter.go
@@ -628,6 +628,7 @@ func tlsConfig(ca string, cert string, key string) (*tls.Config, error) {
 		Certificates: []tls.Certificate{keyPair},
 		RootCAs:      roots,
 		ServerName:   "unbound",
+		MinVersion:   tls.VersionTLS12,
 	}, nil
 }
 


### PR DESCRIPTION
`crypto/tls` sets `MinVersion`, but I want to see it explicitly in this code too.