### PR TITLE
Export server metadata as `unbound_info`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ for [the Unbound DNS resolver](https://unbound.net/). This exporter
 connects to Unbounds TLS control socket and sends the `stats_noreset`
 command, causing Unbound to return metrics as key-value pairs. The
 metrics exporter converts Unbound metric names to Prometheus metric
-names and labels by using a set of regular expressions.
+names and labels by using a set of regular expressions. It also sends
+the `status` command to report the server version, thread count and
+enabled modules as labels on the `unbound_info` metric.
 
 - - - -
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // TestCollect is a basic unit test for parsing the output format
@@ -36,6 +37,47 @@ func TestCollect(t *testing.T) {
 
 	if len(metrics) != 109 {
 		t.Fatal("expected 109 metrics, got ", len(metrics))
+	}
+}
+
+func TestCollectInfo(t *testing.T) {
+	testData, err := os.Open("testdata/status.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch := make(chan prometheus.Metric, 1)
+	if err := collectInfoFromReader(testData, ch); err != nil {
+		t.Fatal(err)
+	}
+	close(ch)
+
+	metric, ok := <-ch
+	if !ok {
+		t.Fatal("expected one metric, got none")
+	}
+
+	var m dto.Metric
+	if err := metric.Write(&m); err != nil {
+		t.Fatal(err)
+	}
+
+	want := map[string]string{
+		"version": "1.25.0",
+		"threads": "16",
+		"modules": "validator iterator",
+	}
+	for _, label := range m.GetLabel() {
+		if want[label.GetName()] != label.GetValue() {
+			t.Errorf("label %s: expected %q, got %q", label.GetName(), want[label.GetName()], label.GetValue())
+		}
+		delete(want, label.GetName())
+	}
+	for name := range want {
+		t.Errorf("missing label %s", name)
+	}
+	if m.GetGauge().GetValue() != 1 {
+		t.Errorf("expected value 1, got %f", m.GetGauge().GetValue())
 	}
 }
 

--- a/exporter/testdata/status.txt
+++ b/exporter/testdata/status.txt
@@ -1,0 +1,7 @@
+version: 1.25.0
+verbosity: 1
+threads: 16
+modules: 2 [ validator iterator ]
+uptime: 243041 seconds
+options: reuseport control(namedpipe)
+unbound (pid 836) is running...

--- a/exporter/unbound_exporter.go
+++ b/exporter/unbound_exporter.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -39,6 +40,11 @@ var (
 		prometheus.BuildFQName("unbound", "", "response_time_seconds"),
 		"Query response time in seconds.",
 		nil, nil)
+
+	unboundInfoDesc = prometheus.NewDesc(
+		prometheus.BuildFQName("unbound", "", "info"),
+		"Metadata about the running Unbound server.",
+		[]string{"version", "threads", "modules"}, nil)
 
 	unboundMetrics = []metricDescription{
 		{
@@ -550,20 +556,79 @@ func collectFromReader(metrics []unboundMetric, file io.Reader, ch chan<- promet
 	return scanner.Err()
 }
 
+// collectInfoFromReader parses "status" command output, which uses
+// "key: value" lines unlike the "key=value" stats format.
+func collectInfoFromReader(file io.Reader, ch chan<- prometheus.Metric) error {
+	// module names sit inside brackets: "2 [ validator iterator ]"
+	modulesPattern := regexp.MustCompile(`\[\s*(.*?)\s*\]`)
+
+	var version, threads, modules string
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, value, found := strings.Cut(scanner.Text(), ":")
+		if !found {
+			continue
+		}
+		value = strings.TrimSpace(value)
+
+		switch key {
+		case "version":
+			version = value
+		case "threads":
+			threads = value
+		case "modules":
+			if matches := modulesPattern.FindStringSubmatch(value); matches != nil {
+				modules = matches[1]
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	if version == "" {
+		return errors.New("no version found in status output")
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		unboundInfoDesc,
+		prometheus.GaugeValue,
+		1.0,
+		version, threads, modules)
+
+	return nil
+}
+
 const (
 	dialTimeout   = 5 * time.Second
 	scrapeTimeout = 10 * time.Second
 )
 
-func (e *UnboundExporter) collectFromSocket(socketFamily string, host string, tlsConfig *tls.Config, ch chan<- prometheus.Metric) (err error) {
+// The control protocol serves one command per connection, so every
+// command needs its own dial.
+func (e *UnboundExporter) dial() (net.Conn, error) {
 	var conn net.Conn
+	var err error
 
 	dialer := net.Dialer{Timeout: dialTimeout}
-	if socketFamily == "unix" || tlsConfig == nil {
-		conn, err = dialer.Dial(socketFamily, host)
+	if e.socketFamily == "unix" || e.tlsConfig == nil {
+		conn, err = dialer.Dial(e.socketFamily, e.host)
 	} else {
-		conn, err = tls.DialWithDialer(&dialer, socketFamily, host, tlsConfig)
+		conn, err = tls.DialWithDialer(&dialer, e.socketFamily, e.host, e.tlsConfig)
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	if err = conn.SetDeadline(time.Now().Add(scrapeTimeout)); err != nil {
+		return nil, errors.Join(err, conn.Close())
+	}
+	return conn, nil
+}
+
+func (e *UnboundExporter) collectFromSocket(ch chan<- prometheus.Metric) (err error) {
+	conn, err := e.dial()
 	if err != nil {
 		return err
 	}
@@ -572,15 +637,28 @@ func (e *UnboundExporter) collectFromSocket(socketFamily string, host string, tl
 		err = errors.Join(err, conn.Close())
 	}()
 
-	if err = conn.SetDeadline(time.Now().Add(scrapeTimeout)); err != nil {
-		return err
-	}
-
 	_, err = conn.Write([]byte("UBCT1 stats_noreset\n"))
 	if err != nil {
 		return err
 	}
 	return collectFromReader(e.metrics, conn, ch)
+}
+
+func (e *UnboundExporter) collectStatus(ch chan<- prometheus.Metric) (err error) {
+	conn, err := e.dial()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = errors.Join(err, conn.Close())
+	}()
+
+	_, err = conn.Write([]byte("UBCT1 status\n"))
+	if err != nil {
+		return err
+	}
+	return collectInfoFromReader(conn, ch)
 }
 
 type UnboundExporter struct {
@@ -665,13 +743,27 @@ func NewUnboundExporter(host string, ca string, cert string, key string, log *sl
 
 func (e *UnboundExporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- unboundUpDesc
+	ch <- unboundInfoDesc
 	for _, metric := range e.metrics {
 		ch <- metric.desc
 	}
 }
 
 func (e *UnboundExporter) Collect(ch chan<- prometheus.Metric) {
-	err := e.collectFromSocket(e.socketFamily, e.host, e.tlsConfig, ch)
+	// Runs concurrently with the stats scrape so a slow status exchange
+	// cannot stretch the scrape beyond its original worst case. A failure
+	// only drops unbound_info; the stats scrape remains the health signal.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := e.collectStatus(ch); err != nil {
+			e.log.Error("Failed to scrape status", "err", err.Error())
+		}
+	}()
+	defer wg.Wait()
+
+	err := e.collectFromSocket(ch)
 	if err == nil {
 		e.unboundUp.Store(true)
 		ch <- prometheus.MustNewConstMetric(

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -48,6 +48,7 @@ func TestIntegration(t *testing.T) {
 	for _, metric := range []string{
 		"go_info",
 		"unbound_exporter_build_info",
+		"unbound_info",
 		"unbound_queries_total",
 		"unbound_response_time_seconds",
 		"unbound_cache_hits_total",


### PR DESCRIPTION
The stats output says nothing about the server itself, so there was no way to track Unbound versions across a large fleet of resolvers. This scrapes the status control command as well and exposes the result as an info-style metric:

```
unbound_info{modules="validator iterator",threads="16",version="1.25.0"} 1
```

The status exchange runs concurrently with the stats scrape to stay off its critical path, and a failure only drops `unbound_info` without affecting `unbound_up`.

Sponsored by: Quad9 Public Resolver